### PR TITLE
fix set date hours to 0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,8 @@ app.get('/cinemas', async (req, res) => {
 app.post('/search', async (req, res) => {
   const movie_name = req.body.movie;
   const movie_date = new Date(req.body.date);
+  movie_date.setHours(0, 0, 0, 0);
+  movie_date.setUTCHours(0);
   var point;
 
   const split_location = req.body.location.split(",");


### PR DESCRIPTION
Era necesario setear las horas y el GMT en 0, ya que el form desde el frontend envía la hora local GMT +3 y en la db las fechas están guardadas con GMT 0 y horas 0.